### PR TITLE
Monday API Update

### DIFF
--- a/src/MondayAPI/ObjectTypes/Column.php
+++ b/src/MondayAPI/ObjectTypes/Column.php
@@ -30,7 +30,7 @@ class Column extends ObjectModel
                 $column_values[$key] = self::newColValue($key, $value);
             }
         }
-        return addslashes(json_encode($column_values, JSON_PRETTY_PRINT));
+        return addslashes(json_encode($column_values));
     }
 
 }


### PR DESCRIPTION
Monday made some changes to their API and it now would fail requests as it follows GraphQL closer.
Removing the JSON_PRETTY_PRINT, seems to have allowed resumption of requests through this library which before were failing.

https://community.monday.com/t/error-when-creating-an-item-with-column-values/55100/3