### PR TITLE
Fixed bug with Parse error on bad Unicode escape sequence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Ignore Mac DS_Store files
 .DS_Store
 _config.yml
+.idea

--- a/src/MondayAPI/ObjectTypes/Column.php
+++ b/src/MondayAPI/ObjectTypes/Column.php
@@ -30,7 +30,7 @@ class Column extends ObjectModel
                 $column_values[$key] = self::newColValue($key, $value);
             }
         }
-        return addslashes(json_encode($column_values, JSON_PRETTY_PRINT));
+        return addslashes(json_encode($column_values));
     }
 
 }


### PR DESCRIPTION
I'm getting the error Parse error on a bad Unicode escape sequence when I've tried to create records on Monday.com. I've found that the problem is because of the last enter in the json of column_values. It could be solved just by removing JSON_PRETTY_PRINT from the Column class.