### PR TITLE
Update PHP version + preparations for API changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     }
   ],
   "require": {
-      "php": ">=5.5.0"
+      "php": ">=7.0",
+      "ext-json": "*"
   },
   "autoload" : {
     "psr-4" : {

--- a/src/MondayAPI/MondayAPI.php
+++ b/src/MondayAPI/MondayAPI.php
@@ -50,7 +50,8 @@ class MondayAPI
             $headers = [
                 'Content-Type: application/json',
                 'User-Agent: [Tblack-IT] GraphQL Client',
-                'Authorization: ' . $this->APIV2_Token->getToken()
+                'Authorization: ' . $this->APIV2_Token->getToken(),
+                'API-Version: 2023-07',
             ];
 
             $data = @file_get_contents($this->API_Url, false, stream_context_create([

--- a/src/MondayAPI/MondayBoard.php
+++ b/src/MondayAPI/MondayBoard.php
@@ -58,6 +58,23 @@ class MondayBoard extends MondayAPI
         return $this->request(self::TYPE_MUTAT, $create);
     }
 
+    public function deleteBoard( Array $fields = [] )
+    {
+        $Board = new Board();
+
+        $arguments = [
+            'board_id'      => $this->board_id,
+        ];
+
+        $create = Query::create(
+            'delete_board',
+            $Board->getArguments($arguments, Board::$archive_arguments),
+            $Board->getFields($fields)
+        );
+
+        return $this->request(self::TYPE_MUTAT, $create);
+    }
+
     public function getBoards( Array $arguments = [], Array $fields = [])
     {
         $Board = new Board();


### PR DESCRIPTION
### Updated PHP Version
  * the version in composer.json was still set to 5.5, while in MondayBoard and MondayApi classes, PHP7 features were used.
  Updated minimum version to 7.0
  * Add ext-json as requirement (default extension, but explicitness can help in case it would be missing)

### Add Delete Board Method
  * Mostly for testing , but this was not yet implemented.

### Specify API version
  * By specifying the API version in the header, we can switch in the code to test both versions