### PR TITLE
Api 2023 10 compatibility (breaking changes, mandatory by 2024-01-15)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     }
   ],
   "require": {
-      "php": ">=5.5.0"
+      "php": ">=7.0",
+      "ext-json": "*"
   },
   "autoload" : {
     "psr-4" : {

--- a/src/MondayAPI/MondayAPI.php
+++ b/src/MondayAPI/MondayAPI.php
@@ -50,7 +50,8 @@ class MondayAPI
             $headers = [
                 'Content-Type: application/json',
                 'User-Agent: [Tblack-IT] GraphQL Client',
-                'Authorization: ' . $this->APIV2_Token->getToken()
+                'Authorization: ' . $this->APIV2_Token->getToken(),
+                'API-Version: 2023-07',
             ];
 
             $data = @file_get_contents($this->API_Url, false, stream_context_create([

--- a/src/MondayAPI/MondayAPI.php
+++ b/src/MondayAPI/MondayAPI.php
@@ -51,7 +51,7 @@ class MondayAPI
                 'Content-Type: application/json',
                 'User-Agent: [Tblack-IT] GraphQL Client',
                 'Authorization: ' . $this->APIV2_Token->getToken(),
-                'API-Version: 2023-10',
+//                'API-Version: 2023-10',
             ];
 
             $data = @file_get_contents($this->API_Url, false, stream_context_create([

--- a/src/MondayAPI/MondayAPI.php
+++ b/src/MondayAPI/MondayAPI.php
@@ -51,7 +51,7 @@ class MondayAPI
                 'Content-Type: application/json',
                 'User-Agent: [Tblack-IT] GraphQL Client',
                 'Authorization: ' . $this->APIV2_Token->getToken(),
-                'API-Version: 2023-07',
+                'API-Version: 2023-10',
             ];
 
             $data = @file_get_contents($this->API_Url, false, stream_context_create([

--- a/src/MondayAPI/MondayBoard.php
+++ b/src/MondayAPI/MondayBoard.php
@@ -58,6 +58,23 @@ class MondayBoard extends MondayAPI
         return $this->request(self::TYPE_MUTAT, $create);
     }
 
+    public function deleteBoard( Array $fields = [] )
+    {
+        $Board = new Board();
+
+        $arguments = [
+            'board_id'      => $this->board_id,
+        ];
+
+        $create = Query::create(
+            'delete_board',
+            $Board->getArguments($arguments, Board::$archive_arguments),
+            $Board->getFields($fields)
+        );
+
+        return $this->request(self::TYPE_MUTAT, $create);
+    }
+
     public function getBoards( Array $arguments = [], Array $fields = [])
     {
         $Board = new Board();

--- a/src/MondayAPI/ObjectTypes/Board.php
+++ b/src/MondayAPI/ObjectTypes/Board.php
@@ -30,7 +30,6 @@ class Board extends ObjectModel
         'name'              => [ 'type' => '!String'      ],
         'owner'             => [ 'type' => '!User'        , 'object' => 'User' ],
         'permissions'       => [ 'type' => '!String'      ],
-        'pos'               => [ 'type' => 'String'        ],
         'state'             => [ 'type' => '!State'        ],
         'subscribers'       => [ 'type' => '![User]'      , 'object' => 'User' ],
         'tags'              => [ 'type' => '[Tag]'        , 'object' => 'Tag' ],

--- a/src/MondayAPI/ObjectTypes/Column.php
+++ b/src/MondayAPI/ObjectTypes/Column.php
@@ -10,7 +10,6 @@ class Column extends ObjectModel
     static $fields = array(
         'archived'       => [ 'type' => '!Boolean',   ],
         'id'             => [ 'type' => '!ID',    ],
-        'pos'            => [ 'type' => 'String',   ],
         'settings_str'   => [ 'type' => '!String',   ],
         'title'          => [ 'type' => '!String',   ],
         'type'           => [ 'type' => '!String',   ],


### PR DESCRIPTION
https://developer.monday.com/api-reference/docs/migrating-to-v-2023-10

### API Version
I Set the API version to 2023-10, where breaking changes were introduced.
I commented this to fall back to default version and not enable the breaking changes before the deadline.

### Breaking changes
Only breaking change I could find of the features that are implemented is that `Pos` fields are deprecated

Other breaking changes seem to be related to retrieving of items, which is not explicitly implemented, and is currently done by using custom Queries. So users need to test / update their queries if they are using this.


